### PR TITLE
experimental/setup-ci   

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI with Kover
+
+on:
+  pull_request:
+    branches: [ main, development ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run-tests:
+    name: Execute Tests & Generate Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Unit Tests
+        run: ./gradlew test
+
+      - name: Generate Kover XML Report
+        run: ./gradlew koverXmlReport
+
+      - name: Upload coverage report XML
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: kover-coverage-report
+          path: build/reports/kover/xml/report.xml
+          retention-days: 1
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "**/build/test-results/**/*.xml"
+        if: always()
+
+      - name: Verify coverage thresholds
+        run: ./gradlew koverVerify
+
+  analyze-pr:
+    name: Analyze PR Code Coverage
+    needs: run-tests
+    runs-on: ubuntu-latest
+    if: ${{ always() && github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for Kover artifact
+        id: check_artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            return artifacts.data.artifacts.some(a => a.name === "kover-coverage-report");
+
+      - name: Download coverage report
+        if: steps.check_artifact.outputs.result == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: kover-coverage-report
+          path: build/reports/kover
+
+      - name: Comment on PR with coverage
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: build/reports/kover/**/xml/report.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+          update-comment: true
+          title: Code Coverage Summary
+          pass-emoji: '✅'
+          fail-emoji: '❌'

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,4 +1,4 @@
-package org.example
+package com.berlin
 
 fun main() {
     println("Hello World!")

--- a/src/test/kotlin/MainKtTest.kt
+++ b/src/test/kotlin/MainKtTest.kt
@@ -1,0 +1,21 @@
+package com.berlin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class MainTest {
+
+    @Test
+    fun `main prints Hello World`() {
+        val buffer = ByteArrayOutputStream()
+        System.setOut(PrintStream(buffer))
+
+        main()
+
+        val output = buffer.toString().trim()
+        assertThat(output)
+            .isEqualTo("Hello World!")
+    }
+}


### PR DESCRIPTION
Integrate the Kotlin Kover plugin to enforce ≥ 80 % line-coverage (excluding any model/di packages), hook koverVerify into ./gradlew check, and add a GitHub Actions workflow that runs this check only on pull requests to main or development.